### PR TITLE
Remove unneeded FOSRest extension, use AbstractController

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 
-dist: trusty
+dist: xenial
 
 sudo: false
 

--- a/src/Controller/NewsletterController.php
+++ b/src/Controller/NewsletterController.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace BitBag\SyliusMailChimpPlugin\Controller;
 
-use FOS\RestBundle\Controller\FOSRestController;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-final class NewsletterController extends FOSRestController
+final class NewsletterController extends AbstractController
 {
     public function subscribeAction(Request $request)
     {


### PR DESCRIPTION
The dependency is not declared on composer.json, that makes compatibility with Sylius 1.9 impossible, because on Sylius 1.9 you need to use fos-rest 3.0 which does not have FOSRestController , but AbstractFOSRestController...

I think this controller does not use anything special to need to extend FOSRestController, we can use AbstractController.