### PR TITLE
Move development dependencies to require-dev, remove ORM conflict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,13 +9,12 @@
         "sylius/sylius": "^1.10",
         "drewm/mailchimp-api": "^v2.5.4",
         "ext-json": "*",
-        "vimeo/psalm": "^4.12",
-        "composer/xdebug-handler": "^2.0",
-        "bitbag/coding-standard": "^1.0"
     },
     "require-dev": {
         "behat/behat": "^3.6.1",
         "behat/mink-selenium2-driver": "^1.4",
+        "bitbag/coding-standard": "^1.0",
+        "composer/xdebug-handler": "^2.0"
         "dmore/behat-chrome-extension": "^1.3",
         "dmore/chrome-mink-driver": "^2.7",
         "friends-of-behat/mink": "^1.8",
@@ -39,12 +38,10 @@
         "symfony/debug-bundle": "^4.4 || ^5.2",
         "symfony/dotenv": "^4.4 || ^5.2",
         "symfony/intl": "^4.4 || ^5.2",
-        "symfony/web-profiler-bundle": "^4.4 || ^5.2"
+        "symfony/web-profiler-bundle": "^4.4 || ^5.2",
+        "vimeo/psalm": "^4.12"
     },
     "prefer-stable": true,
-    "conflict": {
-        "doctrine/orm": "^2.10.0"
-    },
     "autoload": {
         "psr-4": {
             "BitBag\\SyliusMailChimpPlugin\\": "src/",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "behat/behat": "^3.6.1",
         "behat/mink-selenium2-driver": "^1.4",
         "bitbag/coding-standard": "^1.0",
-        "composer/xdebug-handler": "^2.0"
+        "composer/xdebug-handler": "^2.0",
         "dmore/behat-chrome-extension": "^1.3",
         "dmore/chrome-mink-driver": "^2.7",
         "friends-of-behat/mink": "^1.8",

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "php": "^7.3 || ^7.4 || ^8.0",
         "sylius/sylius": "^1.10",
         "drewm/mailchimp-api": "^v2.5.4",
-        "ext-json": "*",
+        "ext-json": "*"
     },
     "require-dev": {
         "behat/behat": "^3.6.1",


### PR DESCRIPTION
1) Psalm and coding standards should not be production dependencies, these packages are moved from the "require" section to the "require-dev" section.

2) The `doctrine/orm` conflict should not be necessary anymore.  The true conflict was between `doctrine/orm` and `gedmo/doctrine-extensions`, with `sylius/sylius` also having this conflict declared for a few releases.  With the latest releases of everything, the conflict shouldn't exist anymore.