### PR TITLE
Update build config to match dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,28 +21,11 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [7.4, 7.3, 8.0]
+                php: [7.4, 8.0]
                 symfony: [^4.4, ^5.2]
-                sylius: [~1.8.0, ~1.9.0, ~1.10.0]
+                sylius: [~1.10.0]
                 node: [10.x]
                 mysql: [5.7]
-
-                exclude:
-                    -
-                        php: 7.3
-                        mysql: 8.0
-                    -
-                        sylius: ~1.8.0
-                        symfony: ^5.2
-                    -
-                        sylius: ~1.8.0
-                        php: 8.0
-                    -
-                        sylius: ~1.9.0
-                        php: 8.0
-                    -
-                        sylius: ~1.10.0
-                        php: 7.3
 
         env:
             APP_ENV: test


### PR DESCRIPTION
I noticed in #50 that there a number of CI builds that run on unsupported environments per the `composer.json` configuration.  This updates the CI build to match the Composer declarations.