### PR TITLE
Move dev dependencies to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,14 +8,13 @@
         "php": "^7.3 || ^7.4 || ^8.0",
         "sylius/sylius": "~1.9.0 || ~1.10.0 || ~1.11.0",
         "drewm/mailchimp-api": "^v2.5.4",
-        "ext-json": "*",
-        "vimeo/psalm": "^4.12",
-        "composer/xdebug-handler": "^2.0",
-        "bitbag/coding-standard": "^1.0"
+        "ext-json": "*"
     },
     "require-dev": {
+        "composer/xdebug-handler": "^2.0",
         "behat/behat": "^3.6.1",
         "behat/mink-selenium2-driver": "^1.4",
+        "bitbag/coding-standard": "^1.0",
         "dmore/behat-chrome-extension": "^1.3",
         "dmore/chrome-mink-driver": "^2.7",
         "friends-of-behat/mink": "^1.8",
@@ -41,7 +40,8 @@
         "symfony/intl": "^4.4 || ^5.2",
         "symfony/web-profiler-bundle": "^4.4 || ^5.2",
         "friendsofsymfony/oauth-server-bundle": "2.*@dev",
-        "polishsymfonycommunity/symfony-mocker-container": "^1.0"
+        "polishsymfonycommunity/symfony-mocker-container": "^1.0",
+        "vimeo/psalm": "^4.12"
     },
     "prefer-stable": true,
     "conflict": {


### PR DESCRIPTION
I'm just gonna say the dev dependencies should not be required on production. Imagine how many downloads it prevented :(