### PR TITLE
fix: correct format in the exception message

### DIFF
--- a/src/Handler/NewsletterSubscriptionHandler.php
+++ b/src/Handler/NewsletterSubscriptionHandler.php
@@ -141,7 +141,7 @@ class NewsletterSubscriptionHandler implements NewsletterSubscriptionInterface
 
             throw new BadRequestHttpException(
                 sprintf(
-                    'Mailchimp returned %1$i code, is the MAIL_CHIMP_LIST_ID [ %2$s ] one of available ones: [ %3$s ] ?',
+                    'Mailchimp returned %1$d code, is the MAIL_CHIMP_LIST_ID [ %2$s ] one of available ones: [ %3$s ] ?',
                     Response::HTTP_NOT_FOUND,
                     $this->listId,
                     $concatenatedList


### PR DESCRIPTION
Fixes the ValueError: `Unknown format specifier "i"`

Since `i` is not a valid specifier for sprintf @see https://www.php.net/manual/en/function.sprintf.php